### PR TITLE
Make game_loop return ! when using winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 window = ["winit"]
 
 [dependencies]
-winit = { version = "0.24", optional = true }
+winit = { version = "0.25", optional = true }
 
 [[example]]
 name = "using_a_window"

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -10,17 +10,23 @@ fn main() {
     game.set(6, 6);
 
     // Run the game loop with 2 updates per second.
-    let g = game_loop(game, 2, 1.0, |g| {
-        g.game.update();
-    }, |g| {
-        // Pass the blending factor (even though this example doesn't use it).
-        g.game.render(g.blending_factor());
+    let g = game_loop(
+        game,
+        2,
+        1.0,
+        |g| {
+            g.game.update();
+        },
+        |g| {
+            // Pass the blending factor (even though this example doesn't use it).
+            g.game.render(g.blending_factor());
 
-        // Exit after 10 seconds.
-        if g.running_time() > 10.0 {
-            g.exit();
-        }
-    });
+            // Exit after 10 seconds.
+            if g.running_time() > 10.0 {
+                g.exit();
+            }
+        },
+    );
 
     // Use the 'g' variable to query the game loop after it finishes.
     println!("Exiting after {} seconds", g.running_time());
@@ -43,7 +49,11 @@ impl GameOfLife {
     fn new(width: usize, height: usize) -> Self {
         let board = vec![vec![false; width]; height];
 
-        Self { board, width, height }
+        Self {
+            board,
+            width,
+            height,
+        }
     }
 
     fn set(&mut self, x: usize, y: usize) {
@@ -55,11 +65,9 @@ impl GameOfLife {
     }
 
     fn next_board(&self) -> Board {
-        (0..self.height).map(|y| {
-            (0..self.width).map(|x| {
-                self.next_cell(x, y)
-            }).collect()
-        }).collect()
+        (0..self.height)
+            .map(|y| (0..self.width).map(|x| self.next_cell(x, y)).collect())
+            .collect()
     }
 
     fn next_cell(&self, x: usize, y: usize) -> bool {
@@ -76,24 +84,30 @@ impl GameOfLife {
     fn neighbors(&self, x: isize, y: isize) -> [bool; 8] {
         [
             self.neighbor(x - 1, y - 1), // top left
-            self.neighbor(x    , y - 1), // above
+            self.neighbor(x, y - 1),     // above
             self.neighbor(x + 1, y - 1), // top right
-            self.neighbor(x - 1, y    ), // left
-            self.neighbor(x + 1, y    ), // right
+            self.neighbor(x - 1, y),     // left
+            self.neighbor(x + 1, y),     // right
             self.neighbor(x - 1, y + 1), // bottom left
-            self.neighbor(x    , y + 1), // below
+            self.neighbor(x, y + 1),     // below
             self.neighbor(x + 1, y + 1), // bottom right
         ]
-
     }
 
     fn neighbor(&self, x: isize, y: isize) -> bool {
-        if x < 0 { return false; }
-        if y < 0 { return false; }
+        if x < 0 {
+            return false;
+        }
+        if y < 0 {
+            return false;
+        }
 
-        *self.board
-            .get(y as usize).unwrap_or(&vec![])
-            .get(x as usize).unwrap_or(&false)
+        *self
+            .board
+            .get(y as usize)
+            .unwrap_or(&vec![])
+            .get(x as usize)
+            .unwrap_or(&false)
     }
 
     fn render(&self, _blending_factor: f64) {

--- a/examples/using_a_window.rs
+++ b/examples/using_a_window.rs
@@ -13,13 +13,24 @@ fn main() {
 
     let game = Game::new();
 
-    game_loop(event_loop, window, game, 240, 0.1, |g| {
-        g.game.your_update_function();
-    }, |g| {
-        g.game.your_render_function(&g.window);
-    }, |g, event| {
-        if !g.game.your_window_handler(event) { g.exit(); }
-    });
+    game_loop(
+        event_loop,
+        window,
+        game,
+        240,
+        0.1,
+        |g| {
+            g.game.your_update_function();
+        },
+        |g| {
+            g.game.your_render_function(&g.window);
+        },
+        |g, event| {
+            if !g.game.your_window_handler(event) {
+                g.exit();
+            }
+        },
+    );
 }
 
 #[derive(Default)]
@@ -46,10 +57,10 @@ impl Game {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => {
                     return false;
-                },
-                _ => {},
+                }
+                _ => {}
             },
-            _ => {},
+            _ => {}
         }
 
         true

--- a/src/base.rs
+++ b/src/base.rs
@@ -40,8 +40,9 @@ impl<G, T: TimeTrait, W> GameLoop<G, T, W> {
     }
 
     pub fn next_frame<U, R>(&mut self, mut update: U, mut render: R) -> bool
-        where U: FnMut(&mut GameLoop<G, T, W>),
-              R: FnMut(&mut GameLoop<G, T, W>),
+    where
+        U: FnMut(&mut GameLoop<G, T, W>),
+        R: FnMut(&mut GameLoop<G, T, W>),
     {
         let mut g = self;
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -2,13 +2,20 @@ use crate::*;
 
 pub use helper::*;
 
-#[cfg(all(not(target_arch = "wasm32"), not(feature="window")))]
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "window")))]
 mod helper {
     use super::*;
 
-    pub fn game_loop<G, U, R>(game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R) -> GameLoop<G, Time, ()>
-        where U: FnMut(&mut GameLoop<G, Time, ()>),
-              R: FnMut(&mut GameLoop<G, Time, ()>),
+    pub fn game_loop<G, U, R>(
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        mut update: U,
+        mut render: R,
+    ) -> GameLoop<G, Time, ()>
+    where
+        U: FnMut(&mut GameLoop<G, Time, ()>),
+        R: FnMut(&mut GameLoop<G, Time, ()>),
     {
         let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, ());
 
@@ -18,17 +25,23 @@ mod helper {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", not(feature="window")))]
+#[cfg(all(target_arch = "wasm32", not(feature = "window")))]
 mod helper {
     use super::*;
-    use web_sys::window;
-    use wasm_bindgen::JsCast;
     use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+    use web_sys::window;
 
-    pub fn game_loop<G, U, R>(game: G, updates_per_second: u32, max_frame_time: f64, update: U, render: R)
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+    pub fn game_loop<G, U, R>(
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        update: U,
+        render: R,
+    ) where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
     {
         let game_loop = GameLoop::new(game, updates_per_second, max_frame_time, ());
 
@@ -36,9 +49,10 @@ mod helper {
     }
 
     fn animation_frame<G, U, R>(mut g: GameLoop<G, Time, ()>, mut update: U, mut render: R)
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+    where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
     {
         if g.next_frame(&mut update, &mut render) {
             let next_frame = move || animation_frame(g, update, render);
@@ -50,7 +64,7 @@ mod helper {
     }
 }
 
-#[cfg(feature="window")]
+#[cfg(feature = "window")]
 mod helper {
     use super::*;
     use winit::event::Event;
@@ -59,11 +73,20 @@ mod helper {
 
     pub use winit;
 
-    pub fn game_loop<G, U, R, H>(event_loop: EventLoop<()>, window: Window, game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R, mut handler: H)
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
-              H: FnMut(&mut GameLoop<G, Time, Window>, Event<()>) + 'static,
+    pub fn game_loop<G, U, R, H>(
+        event_loop: EventLoop<()>,
+        window: Window,
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        mut update: U,
+        mut render: R,
+        mut handler: H,
+    ) where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
+        H: FnMut(&mut GameLoop<G, Time, Window>, Event<()>) + 'static,
     {
         let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, window);
 
@@ -75,10 +98,10 @@ mod helper {
                     if !game_loop.next_frame(&mut update, &mut render) {
                         *control_flow = ControlFlow::Exit;
                     }
-                },
+                }
                 Event::MainEventsCleared => {
                     game_loop.window.request_redraw();
-                },
+                }
                 event => {
                     handler(&mut game_loop, event);
                 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -82,7 +82,8 @@ mod helper {
         mut update: U,
         mut render: R,
         mut handler: H,
-    ) where
+    ) -> !
+    where
         G: 'static,
         U: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
         R: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
@@ -106,6 +107,6 @@ mod helper {
                     handler(&mut game_loop, event);
                 }
             }
-        });
+        })
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,4 @@
-pub trait TimeTrait : Copy {
+pub trait TimeTrait: Copy {
     fn now() -> Self;
     fn sub(&self, other: &Self) -> f64;
 }

--- a/tests/game_loop.rs
+++ b/tests/game_loop.rs
@@ -6,120 +6,239 @@ const GAME: &'static str = "fake game";
 
 #[test]
 fn it_can_exit_the_game_loop_from_the_update_or_render_closure() {
-    game_loop(GAME, 100, 1.0, |g| { g.exit(); }, |_| {});
-    game_loop(GAME, 100, 1.0, |_| {}, |g| { g.exit(); });
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            g.exit();
+        },
+        |_| {},
+    );
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |_| {},
+        |g| {
+            g.exit();
+        },
+    );
 }
 
 #[test]
 fn it_returns_the_control_struct_after_the_game_loop_exits() {
-    let control = game_loop(GAME, 100, 1.0, |g| { g.exit(); }, |_| {});
+    let control = game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            g.exit();
+        },
+        |_| {},
+    );
 
     assert_eq!(control.exit_next_iteration, true);
 }
 
 #[test]
 fn it_provides_game_to_the_closures() {
-    game_loop(GAME, 100, 1.0, |g| {
-        assert_eq!(g.game, "fake game");
-        g.exit();
-    }, |_| {});
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            assert_eq!(g.game, "fake game");
+            g.exit();
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_updates_per_second_to_the_closures() {
-    game_loop(GAME, 100, 1.0, |g| {
-        assert_eq!(g.updates_per_second, 100);
-        g.exit();
-    }, |_| {});
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            assert_eq!(g.updates_per_second, 100);
+            g.exit();
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_max_frame_time_to_the_closures() {
-    game_loop(GAME, 100, 1.0, |g| {
-        assert_eq!(g.max_frame_time, 1.0);
-        g.exit();
-    }, |_| {});
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            assert_eq!(g.max_frame_time, 1.0);
+            g.exit();
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_fixed_time_step_to_the_closures() {
-    game_loop(GAME, 100, 1.0, |g| {
-        assert_eq!(g.fixed_time_step(), 0.01);
-        g.exit();
-    }, |_| {});
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            assert_eq!(g.fixed_time_step(), 0.01);
+            g.exit();
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_number_of_updates_to_the_closures() {
     let mut i = 0;
 
-    game_loop(GAME, 100, 1.0, move |g| {
-        if i == 0 { assert_eq!(g.number_of_updates(), 0); }
-        if i == 1 { assert_eq!(g.number_of_updates(), 1); }
-        if i == 2 { assert_eq!(g.number_of_updates(), 2); }
-        if i == 3 { g.exit(); }
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        move |g| {
+            if i == 0 {
+                assert_eq!(g.number_of_updates(), 0);
+            }
+            if i == 1 {
+                assert_eq!(g.number_of_updates(), 1);
+            }
+            if i == 2 {
+                assert_eq!(g.number_of_updates(), 2);
+            }
+            if i == 3 {
+                g.exit();
+            }
 
-        i += 1;
-    }, |_| {});
+            i += 1;
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_number_of_renders_to_the_closures() {
     let mut i = 0;
 
-    game_loop(GAME, 100, 1.0, |_| {}, move |g| {
-        if i == 0 { assert_eq!(g.number_of_renders(), 0); }
-        if i == 1 { assert_eq!(g.number_of_renders(), 1); }
-        if i == 2 { assert_eq!(g.number_of_renders(), 2); }
-        if i == 3 { g.exit(); }
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |_| {},
+        move |g| {
+            if i == 0 {
+                assert_eq!(g.number_of_renders(), 0);
+            }
+            if i == 1 {
+                assert_eq!(g.number_of_renders(), 1);
+            }
+            if i == 2 {
+                assert_eq!(g.number_of_renders(), 2);
+            }
+            if i == 3 {
+                g.exit();
+            }
 
-        i += 1;
-    });
+            i += 1;
+        },
+    );
 }
-
 
 #[test]
 fn it_provides_running_time_to_the_closures() {
     let mut i = 0;
 
-    game_loop(GAME, 100, 1.0, move |g| {
-        if i == 0 { approx_eq(g.running_time(), 0.01); }
-        if i == 1 { approx_eq(g.running_time(), 0.02); }
-        if i == 2 { approx_eq(g.running_time(), 0.03); }
-        if i == 3 { g.exit(); }
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        move |g| {
+            if i == 0 {
+                approx_eq(g.running_time(), 0.01);
+            }
+            if i == 1 {
+                approx_eq(g.running_time(), 0.02);
+            }
+            if i == 2 {
+                approx_eq(g.running_time(), 0.03);
+            }
+            if i == 3 {
+                g.exit();
+            }
 
-        i += 1;
-    }, |_| {});
+            i += 1;
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_provides_accumulated_time_to_the_closures() {
     let mut i = 0;
 
-    game_loop(GAME, 100, 1.0, move |g| {
-        if i == 0 { approx_eq(g.accumulated_time(), 0.01); }
-        if i == 1 { approx_eq(g.accumulated_time(), 0.01); }
-        if i == 2 { approx_eq(g.accumulated_time(), 0.01); }
-        if i == 3 { g.exit(); }
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        move |g| {
+            if i == 0 {
+                approx_eq(g.accumulated_time(), 0.01);
+            }
+            if i == 1 {
+                approx_eq(g.accumulated_time(), 0.01);
+            }
+            if i == 2 {
+                approx_eq(g.accumulated_time(), 0.01);
+            }
+            if i == 3 {
+                g.exit();
+            }
 
-        i += 1;
-    }, |_| {});
+            i += 1;
+        },
+        |_| {},
+    );
 }
 
 #[test]
 fn it_calls_the_update_function_according_to_updates_per_second() {
-    let control = game_loop(GAME, 100, 1.0, |g| {
-        if g.running_time() > 0.1 { g.exit(); }
-    }, |_| {});
+    let control = game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            if g.running_time() > 0.1 {
+                g.exit();
+            }
+        },
+        |_| {},
+    );
 
     assert_eq!(control.number_of_updates(), 10);
 }
 
 #[test]
 fn it_calls_the_render_function_as_quickly_as_possible() {
-    let control = game_loop(GAME, 100, 1.0, |g| {
-        if g.running_time() > 0.1 { g.exit(); }
-    }, |_| {});
+    let control = game_loop(
+        GAME,
+        100,
+        1.0,
+        |g| {
+            if g.running_time() > 0.1 {
+                g.exit();
+            }
+        },
+        |_| {},
+    );
 
     assert!(control.number_of_renders() > 1000);
 }
@@ -128,44 +247,71 @@ fn it_calls_the_render_function_as_quickly_as_possible() {
 fn it_limits_the_maximum_frame_time_which_reduces_the_number_of_updates() {
     let mut i = 0;
 
-    let g = game_loop(GAME, 100, 0.1, |_| {}, move |g| {
-        if i == 0 { sleep(Duration::from_secs_f64(0.2)) };
-        if i == 1 { g.exit() };
+    let g = game_loop(
+        GAME,
+        100,
+        0.1,
+        |_| {},
+        move |g| {
+            if i == 0 {
+                sleep(Duration::from_secs_f64(0.2))
+            };
+            if i == 1 {
+                g.exit()
+            };
 
-        i += 1;
-    });
+            i += 1;
+        },
+    );
 
     assert_eq!(g.number_of_updates(), 10); // Instead of 20
 }
 
 #[test]
 fn it_provides_blending_factor_so_that_render_can_interpolate_between_frames() {
-    game_loop(GAME, 100, 1.0, |_| {}, |g| {
-        assert!(g.blending_factor() > 0.0);
-        assert!(g.blending_factor() < 0.0001);
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |_| {},
+        |g| {
+            assert!(g.blending_factor() > 0.0);
+            assert!(g.blending_factor() < 0.0001);
 
-        g.exit();
-    });
+            g.exit();
+        },
+    );
 }
 
 #[test]
 fn it_can_re_measure_how_much_time_has_accumulated_mid_way_through_a_render() {
-    game_loop(GAME, 100, 1.0, |_| {}, |g| {
-        sleep(Duration::from_secs_f64(0.2));
-        g.re_accumulate();
+    game_loop(
+        GAME,
+        100,
+        1.0,
+        |_| {},
+        |g| {
+            sleep(Duration::from_secs_f64(0.2));
+            g.re_accumulate();
 
-        approx_eq(g.running_time(), 0.2);
-        approx_eq(g.accumulated_time(), 0.2);
+            approx_eq(g.running_time(), 0.2);
+            approx_eq(g.accumulated_time(), 0.2);
 
-        assert!(g.blending_factor() > 19.);
-        assert!(g.blending_factor() < 21.);
+            assert!(g.blending_factor() > 19.);
+            assert!(g.blending_factor() < 21.);
 
-        g.exit();
-    });
+            g.exit();
+        },
+    );
 }
 
 fn approx_eq(actual: f64, expected: f64) {
     let delta = (actual - expected).abs();
 
-    assert!(delta < 0.005, "{} is not approximately {}", actual, expected);
+    assert!(
+        delta < 0.005,
+        "{} is not approximately {}",
+        actual,
+        expected
+    );
 }


### PR DESCRIPTION
The winit event loop actually never returns, so this is a bit cleaner.
I also ran rustfmt using the default settings.