### PR TITLE
Allow using winit user events

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -59,11 +59,12 @@ mod helper {
 
     pub use winit;
 
-    pub fn game_loop<G, U, R, H>(event_loop: EventLoop<()>, window: Window, game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R, mut handler: H) -> !
+    pub fn game_loop<G, U, R, H, T>(event_loop: EventLoop<T>, window: Window, game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R, mut handler: H) -> !
         where G: 'static,
               U: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
               R: FnMut(&mut GameLoop<G, Time, Window>) + 'static,
-              H: FnMut(&mut GameLoop<G, Time, Window>, Event<()>) + 'static,
+              H: FnMut(&mut GameLoop<G, Time, Window>, Event<'_, T>) + 'static,
+              T: 'static,
     {
         let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, window);
 


### PR DESCRIPTION
When creating an event loop with `EventLoop::with_user_event()`, the user specifies a generic type for `Event::UserEvent`. These events can be sent via `EventLoopProxy`. An [example is available](https://github.com/rust-windowing/winit/blob/master/examples/custom_events.rs).

This PR allows all this machinery to be used with `game-loop`.