### PR TITLE
Forward MainEventsCleared to the handler closure

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -78,6 +78,7 @@ mod helper {
                     }
                 },
                 Event::MainEventsCleared => {
+                    handler(&mut game_loop, Event::MainEventsCleared);
                     game_loop.window.request_redraw();
                 },
                 event => {


### PR DESCRIPTION
An issue was reported on my project that claimed this crate is incompatible with the `winit_input_helper` crate: https://github.com/parasyte/pixels/issues/270

That issue helped identify that the underlying cause of the incompatibility could cause other problems as well. This PR forwards the `MainEventsCleared` event from winit to the handler closure, allowing the handler to make more decisions. A common thing to do in response to `MainEventsCleared` is finalize any inputs (like polling gamepads) and call `request_redraw` (`game-loop` already does this for us!) Without the event, I have to poll the gamepad on every event received by the handler closure. I have no other way to tell that `game-loop` is about to call my update and render closures.

I could move gamepad polling to the update closure, but it is potentially called multiple times per frame. I can't move it to the render callback because that would be too late; gamepad inputs will be delayed by a frame.

With this patch, `winit_input_helper` is now compatible (bonus!) and users can do their gamepad polling in response to the `MainEventCleared` event instead of needlessly polling multiple times per frame.