### PR TITLE
Only call render function when window is visible for macOS and X11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 window = ["winit"]
 
 [dependencies]
-winit = { version = "0.26", optional = true }
+winit = { git = "https://github.com/trimental/winit", branch = "macos-is-occluded", optional = true }
 
 [[example]]
 name = "using_a_window"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 window = ["winit"]
 
 [dependencies]
-winit = { git = "https://github.com/trimental/winit", branch = "macos-is-occluded", optional = true }
+winit = { version = "0.27", optional = true}
 
 [[example]]
 name = "using_a_window"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,7 +1,4 @@
 use crate::*;
-use std::time::Duration;
-use std::thread::sleep;
-
 pub struct GameLoop<G, T: TimeTrait, W> {
     pub game: G,
     pub updates_per_second: u32,
@@ -64,9 +61,12 @@ impl<G, T: TimeTrait, W> GameLoop<G, T, W> {
         g.last_frame_time = elapsed;
         g.running_time += elapsed;
         g.accumulated_time += elapsed;
+        if g.accumulated_time < g.fixed_time_step && g.occluded && cfg!(not(target_arch = "wasm32")) {
+            #[cfg(not(target_arch = "wasm32"))]
+            std::thread::sleep(std::time::Duration::from_secs_f64(
+                g.fixed_time_step - g.accumulated_time,
+            ));
 
-        if g.accumulated_time < g.fixed_time_step && g.occluded {
-            sleep(Duration::from_secs_f64(g.fixed_time_step - g.accumulated_time));
             update(&mut g);
 
             g.accumulated_time -= g.fixed_time_step;

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -53,7 +53,7 @@ mod helper {
 #[cfg(feature="window")]
 mod helper {
     use super::*;
-    use winit::event::Event;
+    use winit::event::{Event, WindowEvent};
     use winit::event_loop::{ControlFlow, EventLoop};
     use winit::window::Window;
 
@@ -83,6 +83,9 @@ mod helper {
                 Event::MainEventsCleared => {
                     game_loop.window.request_redraw();
                 },
+                Event::WindowEvent { event, .. } => if let WindowEvent::Occluded(occluded) = event {
+                    game_loop.occluded = occluded;
+                }
                 _ => {},
             }
         })


### PR DESCRIPTION
This functionality depends upon a PR I've put in for winit, but I'm sending this PR now to check if it's viable for this crate.

Basically it makes it so that on macOS the render function is only called when the winit window is visible, whilst keeping the update function the same. The reasons for this are A) the game loop can sleep in-between calls to update which significantly saves cpu time, B) since the rendering code won't be called, it significantly saves either cpu and/or gpu time; provided the window is not visible to the user.

In a non scientific test, my games go from 12-18% cpu usage, when the window is in the background, to about 3-4%.

