### PR TITLE
Update winit to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 window = ["winit"]
 
 [dependencies]
-winit = { version = "0.26", optional = true }
+winit = { version = "0.27", optional = true }
 
 [[example]]
 name = "using_a_window"

--- a/examples/using_a_window.rs
+++ b/examples/using_a_window.rs
@@ -41,7 +41,7 @@ impl Game {
     }
 
     // A very simple handler that returns false when CloseRequested is detected.
-    pub fn your_window_handler(&self, event: Event<()>) -> bool {
+    pub fn your_window_handler(&self, event: &Event<()>) -> bool {
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => {


### PR DESCRIPTION
- Also fixes a build error in the window example

This is an alternative to #11 to get the base crate updated sooner than later.