### PR TITLE
Disable the wasm32 helper when winit is enabled

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -18,7 +18,7 @@ mod helper {
     }
 }
 
-#[cfg(all(target_arch = "wasm32"))]
+#[cfg(all(target_arch = "wasm32", not(feature = "winit")))]
 mod helper {
     use super::*;
     use web_sys::window;


### PR DESCRIPTION
The winit feature conflicts with target_arch=wasm32. This is problematic, as Winit should normally be compatible with WASM. 

The issue can be fixed by disabling the wasm32 helper module when the winit feature is active. 