### PR TITLE
Prevent overflow with fast render/update

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -62,7 +62,7 @@ impl<G, T: TimeTrait, W> GameLoop<G, T, W> {
             update(g);
 
             g.accumulated_time -= g.fixed_time_step;
-            g.number_of_updates += 1;
+            g.number_of_updates = g.number_of_updates.wrapping_add(1);
         }
 
         g.blending_factor = g.accumulated_time / g.fixed_time_step;
@@ -71,7 +71,7 @@ impl<G, T: TimeTrait, W> GameLoop<G, T, W> {
             T::sleep(g.fixed_time_step);
         } else {
             render(g);
-            g.number_of_renders += 1;
+            g.number_of_renders = g.number_of_renders.wrapping_add(1);
         }
 
         g.previous_instant = g.current_instant;

--- a/src/base.rs
+++ b/src/base.rs
@@ -9,8 +9,8 @@ pub struct GameLoop<G, T: TimeTrait, W> {
     pub window_occluded: bool,
 
     fixed_time_step: f64,
-    number_of_updates: u32,
-    number_of_renders: u32,
+    number_of_updates: u64,
+    number_of_renders: u64,
     last_frame_time: f64,
     running_time: f64,
     accumulated_time: f64,
@@ -111,11 +111,11 @@ impl<G, T: TimeTrait, W> GameLoop<G, T, W> {
         self.fixed_time_step
     }
 
-    pub fn number_of_updates(&self) -> u32 {
+    pub fn number_of_updates(&self) -> u64 {
         self.number_of_updates
     }
 
-    pub fn number_of_renders(&self) -> u32 {
+    pub fn number_of_renders(&self) -> u64 {
         self.number_of_renders
     }
 


### PR DESCRIPTION
I noticed that with an extremely fast render or update function, the program would overflow after an insubstantial amount of time. This is simple fix.