### PR TITLE
fix(deps)!: update winit to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [dependencies]
-winit = { version = "0.28", optional = true }
+winit = { version = "0.29", optional = true }
 tao = { version = "0.21", optional = true }
 
 [[example]]

--- a/examples/using_winit.rs
+++ b/examples/using_winit.rs
@@ -9,20 +9,32 @@ use game_loop::winit::window::{Window, WindowBuilder};
 use std::sync::Arc;
 
 fn main() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new().build(&event_loop).unwrap();
     let window = Arc::new(window);
 
     let game = Game::new();
 
-    game_loop(event_loop, window, game, 240, 0.1, |g| {
-        g.game.your_update_function();
-    }, |g| {
-        g.game.your_render_function(&g.window);
-    }, |g, event| {
-        if !g.game.your_window_handler(event) { g.exit(); }
-    });
+    game_loop(
+        event_loop,
+        window,
+        game,
+        240,
+        0.1,
+        |g| {
+            g.game.your_update_function();
+        },
+        |g| {
+            g.game.your_render_function(&g.window);
+        },
+        |g, event| {
+            if !g.game.your_window_handler(event) {
+                g.exit();
+            }
+        },
+    )
+    .unwrap();
 }
 
 #[derive(Default)]
@@ -42,7 +54,10 @@ impl Game {
 
     pub fn your_render_function(&mut self, window: &Window) {
         self.num_renders += 1;
-        window.set_title(&format!("num_updates: {}, num_renders: {}", self.num_updates, self.num_renders));
+        window.set_title(&format!(
+            "num_updates: {}, num_renders: {}",
+            self.num_updates, self.num_renders
+        ));
     }
 
     // A very simple handler that returns false when CloseRequested is detected.
@@ -51,10 +66,10 @@ impl Game {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => {
                     return false;
-                },
-                _ => {},
+                }
+                _ => {}
             },
-            _ => {},
+            _ => {}
         }
 
         true

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -2,13 +2,24 @@ use crate::*;
 
 pub use helper::*;
 
-#[cfg(all(not(target_arch = "wasm32"), not(feature="winit"), not(feature="tao")))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(feature = "winit"),
+    not(feature = "tao")
+))]
 mod helper {
     use super::*;
 
-    pub fn game_loop<G, U, R>(game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R) -> GameLoop<G, Time, ()>
-        where U: FnMut(&mut GameLoop<G, Time, ()>),
-              R: FnMut(&mut GameLoop<G, Time, ()>),
+    pub fn game_loop<G, U, R>(
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        mut update: U,
+        mut render: R,
+    ) -> GameLoop<G, Time, ()>
+    where
+        U: FnMut(&mut GameLoop<G, Time, ()>),
+        R: FnMut(&mut GameLoop<G, Time, ()>),
     {
         let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, ());
 
@@ -21,14 +32,20 @@ mod helper {
 #[cfg(all(target_arch = "wasm32", not(feature = "winit")))]
 mod helper {
     use super::*;
-    use web_sys::window;
-    use wasm_bindgen::JsCast;
     use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+    use web_sys::window;
 
-    pub fn game_loop<G, U, R>(game: G, updates_per_second: u32, max_frame_time: f64, update: U, render: R)
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+    pub fn game_loop<G, U, R>(
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        update: U,
+        render: R,
+    ) where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
     {
         let game_loop = GameLoop::new(game, updates_per_second, max_frame_time, ());
 
@@ -36,9 +53,10 @@ mod helper {
     }
 
     fn animation_frame<G, U, R>(mut g: GameLoop<G, Time, ()>, mut update: U, mut render: R)
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+    where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, ()>) + 'static,
     {
         if g.next_frame(&mut update, &mut render) {
             let next_frame = move || animation_frame(g, update, render);
@@ -50,44 +68,57 @@ mod helper {
     }
 }
 
-#[cfg(feature="winit")]
+#[cfg(feature = "winit")]
 mod helper {
-    use std::sync::Arc;
     use super::*;
+    use std::sync::Arc;
     use winit::event::{Event, WindowEvent};
     use winit::event_loop::{ControlFlow, EventLoop};
     use winit::window::Window;
 
     pub use winit;
 
-    pub fn game_loop<G, U, R, H, T>(event_loop: EventLoop<T>, window: Arc<Window>, game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R, mut handler: H) -> !
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
-              H: FnMut(&mut GameLoop<G, Time, Arc<Window>>, &Event<'_, T>) + 'static,
-              T: 'static,
+    pub fn game_loop<G, U, R, H, T>(
+        event_loop: EventLoop<T>,
+        window: Arc<Window>,
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        mut update: U,
+        mut render: R,
+        mut handler: H,
+    ) -> Result<(), impl std::error::Error>
+    where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
+        H: FnMut(&mut GameLoop<G, Time, Arc<Window>>, &Event<T>) + 'static,
+        T: 'static,
     {
-        let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, window);
+        let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, window.clone());
 
-        event_loop.run(move |event, _, control_flow| {
-            *control_flow = ControlFlow::Poll;
+        event_loop.run(move |event, elwt| {
+            elwt.set_control_flow(ControlFlow::Poll);
 
             // Forward events to existing handlers.
             handler(&mut game_loop, &event);
 
             match event {
-                Event::RedrawRequested(_) => {
-                    if !game_loop.next_frame(&mut update, &mut render) {
-                        *control_flow = ControlFlow::Exit;
+                Event::WindowEvent { event, window_id } if window_id == window.id() => {
+                    match event {
+                        WindowEvent::Occluded(occluded) => game_loop.window_occluded = occluded,
+                        WindowEvent::RedrawRequested => {
+                            if !game_loop.next_frame(&mut update, &mut render) {
+                                elwt.exit();
+                            }
+                        }
+                        _ => (),
                     }
-                },
-                Event::MainEventsCleared => {
+                }
+                Event::AboutToWait => {
                     game_loop.window.request_redraw();
-                },
-                Event::WindowEvent { event: WindowEvent::Occluded(occluded), .. } => {
-                    game_loop.window_occluded = occluded;
-                },
-                _ => {},
+                }
+                _ => (),
             }
         })
     }
@@ -96,19 +127,29 @@ mod helper {
 #[cfg(feature = "tao")]
 mod helper {
     use super::*;
+    use std::sync::Arc;
     use tao::event::Event;
     use tao::event_loop::{ControlFlow, EventLoop};
     use tao::window::Window;
-    use std::sync::Arc;
 
     pub use tao;
 
-    pub fn game_loop<G, U, R, H, T>(event_loop: EventLoop<T>, window: Arc<Window>, game: G, updates_per_second: u32, max_frame_time: f64, mut update: U, mut render: R, mut handler: H) -> !
-        where G: 'static,
-              U: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
-              R: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
-              H: FnMut(&mut GameLoop<G, Time, Arc<Window>>, &Event<'_, T>) + 'static,
-              T: 'static,
+    pub fn game_loop<G, U, R, H, T>(
+        event_loop: EventLoop<T>,
+        window: Arc<Window>,
+        game: G,
+        updates_per_second: u32,
+        max_frame_time: f64,
+        mut update: U,
+        mut render: R,
+        mut handler: H,
+    ) -> !
+    where
+        G: 'static,
+        U: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
+        R: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,
+        H: FnMut(&mut GameLoop<G, Time, Arc<Window>>, &Event<'_, T>) + 'static,
+        T: 'static,
     {
         let mut game_loop = GameLoop::new(game, updates_per_second, max_frame_time, window);
 
@@ -123,11 +164,11 @@ mod helper {
                     if !game_loop.next_frame(&mut update, &mut render) {
                         *control_flow = ControlFlow::Exit;
                     }
-                },
+                }
                 Event::MainEventsCleared => {
                     game_loop.window.request_redraw();
-                },
-                _ => {},
+                }
+                _ => {}
             }
         })
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -72,6 +72,7 @@ mod helper {
 mod helper {
     use super::*;
     use std::sync::Arc;
+    use winit::error::EventLoopError;
     use winit::event::{Event, WindowEvent};
     use winit::event_loop::{ControlFlow, EventLoop};
     use winit::window::Window;
@@ -87,7 +88,7 @@ mod helper {
         mut update: U,
         mut render: R,
         mut handler: H,
-    ) -> Result<(), impl std::error::Error>
+    ) -> Result<(), EventLoopError>
     where
         G: 'static,
         U: FnMut(&mut GameLoop<G, Time, Arc<Window>>) + 'static,


### PR DESCRIPTION
My editor also applied `cargo fmt`.

It's a breaking change because a winit error is returned and because the winit versions are not compatible.